### PR TITLE
Refactor: add authorization header to API request

### DIFF
--- a/admin/src/components/Input/index.js
+++ b/admin/src/components/Input/index.js
@@ -75,7 +75,12 @@ const Tags = ({
       return [];
     }
     try {
-      const res = await axios.get(attribute.options["apiUrl"]);
+      const token = attribute.options["apiToken"];
+      const res = await axios.get(attribute.options["apiUrl"], {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
       setSuggestions(res.data);
     } catch (err) {
       console.log(err);

--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -38,6 +38,16 @@ export default {
                 value: "",
                 options: [],
               },
+              {
+                intlLabel: {
+                  id: "tagsinput.tags.section.apiUrl",
+                  defaultMessage: "API Token",
+                },
+                name: "options.apiToken",
+                type: "text",
+                value: "",
+                options: [],
+              },
             ],
           },
         ],


### PR DESCRIPTION
Disclaimer:  I am new to strapi.
The plugin did not work for me as I was missing a token to authenticate the request. So I did a little modification to put the token so suggestions work.

![image](https://github.com/user-attachments/assets/9f0c13bc-5fcf-4893-83b9-085745a92842)

