### PR TITLE
Bump to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-tagsinput",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Tagsinput plugin for your strapi project",
   "strapi": {
     "name": "tagsinput",


### PR DESCRIPTION
- Added compatibility with Strapi 5 (Closes [#17](https://github.com/canopas/strapi-plugin-tagsinput/issues/17) & [#18](https://github.com/canopas/strapi-plugin-tagsinput/issues/18))