### PR TITLE
Change defaultMessage to label for better distinction when multiple tags are present

### DIFF
--- a/admin/src/components/Input.jsx
+++ b/admin/src/components/Input.jsx
@@ -176,7 +176,7 @@ const Tags = ({
           style={{ position: "relative" }}
           ref={inputEle}
         >
-          {label && <Field.Label action={labelAction}>{formatMessage({ id: label, defaultMessage: "Tags" })}</Field.Label>}
+          {label && <Field.Label action={labelAction}>{formatMessage({ id: label, defaultMessage: label })}</Field.Label>}
           <ThemeStyle />
           <Flex direction="column">
             <TagsInput


### PR DESCRIPTION
Hi there 👋

This PR fixes an issue where the label for custom tag fields was always set to "Tags". When a page contains multiple custom tag fields, this made it hard to distinguish between them. The fix ensures that each tag field uses its own label instead, allowing for better clarity and usability.

Let me know if any adjustments are needed!