### PR TITLE
fix: prevent error when lastTag is undefined

### DIFF
--- a/admin/src/components/Input.jsx
+++ b/admin/src/components/Input.jsx
@@ -62,10 +62,10 @@ const Tags = ({
     const lastTag = newTags[newTags.length - 1];
     const suggestionsArray = suggestions.data || [];
     const existingTag = suggestionsArray.find(
-      (s) => s[attrName]?.toLowerCase() === lastTag.toLowerCase()
+      (s) => s[attrName]?.toLowerCase() === lastTag?.toLowerCase()
     );
 
-    if (!existingTag) {
+    if (lastTag && !existingTag) {
       if (apiUrl) {
         try {
           const response = await axios.post(apiUrl, {


### PR DESCRIPTION
Added a check to ensure lastTag exists before proceeding with change handler execution. This should fix the problem which occurs when user tries to delete the last tag from the input field - #43 