### PR TITLE
feat: improve theme handling by adding system preference support

### DIFF
--- a/admin/src/components/Input.jsx
+++ b/admin/src/components/Input.jsx
@@ -6,8 +6,9 @@ import { useIntl } from "react-intl";
 import TagsInput from "react-tagsinput";
 import Autosuggest from "react-autosuggest";
 import { getStyling } from "./styles/global";
+import { getCurrentTheme } from '../utils/getCurrentTheme';
 
-const ThemeStyle = getStyling(localStorage.getItem("STRAPI_THEME"));
+const ThemeStyle = getStyling(getCurrentTheme());
 
 const Tags = ({
   attribute,
@@ -145,7 +146,7 @@ const Tags = ({
           [attrName]: state[attrName] || "",
         }));
     }
-    
+
     return (
       <Autosuggest
         ref={props.ref}

--- a/admin/src/utils/getCurrentTheme.js
+++ b/admin/src/utils/getCurrentTheme.js
@@ -1,0 +1,6 @@
+export const getCurrentTheme = () => {
+  const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? "dark" : "light";
+  const strapiTheme = localStorage.getItem("STRAPI_THEME");
+
+  return (!strapiTheme || strapiTheme === 'system') ? systemTheme : strapiTheme;
+};


### PR DESCRIPTION
Refactored theme logic to use a utility function `getCurrentTheme`, which considers system color scheme preference and stored theme settings.

Currently when user is using dark theme set as default on the system level, the styles are incorrectly applied